### PR TITLE
fix: disabled pattern-matching for string.find()

### DIFF
--- a/suricata_rules/dns_heap_overflow_variant_2.lua
+++ b/suricata_rules/dns_heap_overflow_variant_2.lua
@@ -51,7 +51,7 @@ function match(args)
     for i = 1, answer_rrs do
 
         -- We're looking for 0x00 0x05 0x00 0x01 bytes to indicate TYPE=CNAME, CLASS=IN.
-        s[i], e[i] = string.find(payload, "\000\005\000\001", offset)
+        s[i], e[i] = string.find(payload, "\000\005\000\001", offset, true)
         if s[i] == nil then
             break
         end

--- a/suricata_rules/dns_size.lua
+++ b/suricata_rules/dns_size.lua
@@ -44,7 +44,7 @@ function match(args)
         local additional_rrs = get_short(11)
         if additional_rrs > 0 then
             -- We're looking for 0x00 0x00 0x29 for the NAME and TYPE fields. RFC requires these values for the OPT RR.
-            local s, e = string.find(payload, "\000\000\041", 13)    -- First 12 bytes are fixed-length fields.
+            local s, e = string.find(payload, "\000\000\041", 13, true)    -- First 12 bytes are fixed-length fields.
             if s then
                 local edns_max_len = get_short(e + 1)
 

--- a/suricata_rules/tunnel_length_check.lua
+++ b/suricata_rules/tunnel_length_check.lua
@@ -19,7 +19,7 @@ function match(args)
 
    --find beginning of inner packet
    --start from IP protocol field in header
-   s,e	= string.find(b,"\004")
+   s,e	= string.find(b,"\004", 1, true)
    --inner packet should start 18 bytes later
    inner_packet = string.sub(b, s+18)
 


### PR DESCRIPTION
same issue as https://github.com/advanced-threat-research/CVE-2020-16898/pull/2